### PR TITLE
Fixes zookeeper connection leak for websockets

### DIFF
--- a/src/socketIo.ts
+++ b/src/socketIo.ts
@@ -9,7 +9,7 @@ import redis = require('redis');
 import {RedisManager} from './redisManager';
 
 import {KafkaConsumer} from './consumer';
-import {TopicManager} from './topicManager';
+import {TopicManagerBuilder} from './topicManager';
 
 function getKey(token:string): string {
   return 'si:' + token;
@@ -108,7 +108,7 @@ class SocketIOHandler {
   }
 
   getToken(tenant:string) {
-    let topicManager = new TopicManager(tenant);
+    let topicManager = TopicManagerBuilder.get(tenant);
     topicManager.getCreateTopic('device-data', (error?:any, topic?:string) => {
       if (error || !topic) {
         console.error('Failed to find appropriate topic for tenant: ',


### PR DESCRIPTION
Whenever a client would request a new websocket token, data-broker would create a brand new zookeeper connection to validate the underlying kafka topic. As those were not properly closed (or reused) eventually zookeeper would, to protect itself, deny new connections, rendering the broker unusable.

This applies the patch made to subject retrieval to socketio.

This is connected to dojot/dojot#423