### PR TITLE
ci: changing docker base image to a more stable one

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,20 @@
-FROM node:8
+FROM node:8.14.0-alpine as basis
 
-WORKDIR /opt/subscription-manager
-EXPOSE 80
-CMD ["npm", "run", "subscription"]
+WORKDIR /opt/data-broker
+
+RUN apk add git python make bash gcc g++ --no-cache
 
 COPY package.json .
 COPY package-lock.json .
-RUN npm install
 
+RUN npm install
 COPY . .
 RUN npm run-script build
+
+
+FROM node:8.14.0-alpine
+COPY --from=basis  /opt/data-broker /opt/data-broker
+WORKDIR /opt/data-broker
+EXPOSE 80
+CMD ["npm", "run", "subscription"]
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR updates the base image for data-broker to node:8.14.0-alpine. As a side effect, the image was reduced from ~940MB to ~200MB


* **What is the current behavior?** (You can also link to an open issue here)
The base image is prone to updates from their maintainers without prior notice. This leads to errors in our side, as things might change in an unexpected way.


* **What is the new behavior (if this is a feature change)?**
The base image is node:8.14.0-alpine, which is very unlikely to be updated automatically (aside from bugfix updates, if any).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is child of dojot/dojot#797

* **Other information**:
