### PR TITLE
ci: changing how to set user password while pushing docker image

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -ex
+if [ $TRAVIS_PULL_REQUEST == false ] ; then
+  version="latest"
+  if [ $TRAVIS_BRANCH != "master" ] ; then
+    version=$TRAVIS_BRANCH
+  fi
 
-version="latest"
-if [ $TRAVIS_BRANCH != "master" ] ; then
-  version=$TRAVIS_BRANCH
+  tag=${TRAVIS_REPO_SLUG}:$version
+
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  docker tag ${TRAVIS_REPO_SLUG} ${tag}
+  docker push $tag
 fi
-tag=$TRAVIS_REPO_SLUG:$version
-
-docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-docker tag ${TRAVIS_REPO_SLUG} ${tag}
-docker push $tag


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a check when running jobs in Travis. Without it, PR could update the image tagged `latest` in DockerHub


* **What is the current behavior?** (You can also link to an open issue here)
There is a chance that simply creating a pull-request could trigger a deploy to Docker Hub.


* **What is the new behavior (if this is a feature change)?**
The type of build is checked, thus avoiding PR to be considered when deploying images to Docker Hub.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is child of dojot/dojot#794

* **Other information**:
