### PR TITLE
fix: adding zlib-dev to be installed in base image in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8.14.0-alpine as basis
 
 WORKDIR /opt/data-broker
 
-RUN apk add git python make bash gcc g++ --no-cache
+RUN apk add git python make bash gcc g++ zlib-dev --no-cache
 
 COPY package.json .
 COPY package-lock.json .


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the zlib-dev package in Dockerfile.


* **What is the current behavior?** (You can also link to an open issue here)
DataBroker can't create KafkaProducers once it has no zip support.


* **What is the new behavior (if this is a feature change)?**
Zip support is compiled when installing dojot-module (which in turn will build librdkafka with this support).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No.

* **Other information**:
