### PR TITLE
Changed to not run data-broker process as PID1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN npm run-script build
 
 
 FROM node:8.14.0-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 COPY --from=basis  /opt/data-broker /opt/data-broker
 WORKDIR /opt/data-broker
 EXPOSE 80


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
The databroker run as PID1, but it was not designed for this. 


* **What is the new behavior (if this is a feature change)?**
The tini runs as PID 1 and databroker runs as its child.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No.

* **Other information**:
