### PR TITLE
ci: changing docker image name

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -5,7 +5,10 @@ if [ $TRAVIS_PULL_REQUEST == false ] ; then
     version=$TRAVIS_BRANCH
   fi
 
-  tag=${TRAVIS_REPO_SLUG}:$version
+
+  DOCKER_TAG=$(echo ${version} | sed 's/\(.*\)\/\(.*\)/\1_\2/')
+
+  tag=${TRAVIS_REPO_SLUG}:${DOCKER_TAG}
 
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   docker tag ${TRAVIS_REPO_SLUG} ${tag}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This commit changes how the publish.sh script will generate image names. As gitflow has slashes in its branches, this script will now substitute them to underscores.


* **What is the current behavior?** (You can also link to an open issue here)
Using invalid characters for docker image in branch names won't generate any image.


* **What is the new behavior (if this is a feature change)?**
All slashes will be changed to underscores.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#986

* **Other information**:
