### PR TITLE
Add SERVICE_PORT variable usage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ const healthcheck = {
 };
 
 const service = {
-  port: Number(process.env.SERVICE_PORT) || 80
-}
+  port: Number(process.env.SERVICE_PORT) || 80,
+};
 
 export { kafka, broker, cache, healthcheck, service };

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,4 +29,8 @@ const healthcheck = {
   },
 };
 
-export { kafka, broker, cache, healthcheck};
+const service = {
+  port: Number(process.env.SERVICE_PORT) || 80
+}
+
+export { kafka, broker, cache, healthcheck, service };

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -12,6 +12,7 @@ import { RedisManager } from "./redisManager";
 import { SocketIOSingleton } from "./socketIo";
 import { SubscriptionEngine, SubscriptionType } from "./subscription-engine";
 import { TopicManagerBuilder } from "./TopicBuilder";
+import config = require("./config");
 
 const TAG = { filename: "sub-mng" };
 
@@ -61,10 +62,9 @@ class DataBroker {
     this.registerTopicEndpoints();
     logger.debug("... common endpoints were registered.", TAG);
 
-    const servicePort = process.env.SERVICE_PORT || 80;
     logger.debug("Starting HTTP server...", TAG);
-    httpServer.listen(servicePort, () => {
-      logger.debug(`Subscription manager listening on port ${servicePort}`, TAG);
+    httpServer.listen(config.service.port, () => {
+      logger.debug(`Subscription manager listening on port ${config.service.port}`, TAG);
     });
     logger.debug("... HTTP server startup requested.", TAG);
   }

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -61,7 +61,7 @@ class DataBroker {
     this.registerTopicEndpoints();
     logger.debug("... common endpoints were registered.", TAG);
 
-    let servicePort = process.env.SERVICE_PORT || 80;
+    const servicePort = process.env.SERVICE_PORT || 80;
     logger.debug("Starting HTTP server...", TAG);
     httpServer.listen(servicePort, () => {
       logger.debug(`Subscription manager listening on port ${servicePort}`, TAG);

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -1,6 +1,7 @@
 import { Messenger } from "@dojot/dojot-module";
 import { getHTTPRouter as getLoggerRouter, logger } from "@dojot/dojot-module-logger";
 import bodyParser = require("body-parser");
+import config = require("./config");
 import express = require("express");
 import http = require("http");
 import morgan = require("morgan");
@@ -12,7 +13,6 @@ import { RedisManager } from "./redisManager";
 import { SocketIOSingleton } from "./socketIo";
 import { SubscriptionEngine, SubscriptionType } from "./subscription-engine";
 import { TopicManagerBuilder } from "./TopicBuilder";
-import config = require("./config");
 
 const TAG = { filename: "sub-mng" };
 

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -1,12 +1,12 @@
 import { Messenger } from "@dojot/dojot-module";
 import { getHTTPRouter as getLoggerRouter, logger } from "@dojot/dojot-module-logger";
 import bodyParser = require("body-parser");
-import config = require("./config");
 import express = require("express");
 import http = require("http");
 import morgan = require("morgan");
 import util = require("util");
 import { authEnforce, authParse, IAuthRequest } from "./api/authMiddleware";
+import config = require("./config");
 import { AgentHealthChecker } from "./Healthcheck";
 import { ITopicProfile } from "./RedisClientWrapper";
 import { RedisManager } from "./redisManager";

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -61,9 +61,10 @@ class DataBroker {
     this.registerTopicEndpoints();
     logger.debug("... common endpoints were registered.", TAG);
 
+    let servicePort = process.env.SERVICE_PORT || 80;
     logger.debug("Starting HTTP server...", TAG);
-    httpServer.listen(80, () => {
-      logger.debug("Subscription manager listening on port 80", TAG);
+    httpServer.listen(servicePort, () => {
+      logger.debug(`Subscription manager listening on port ${servicePort}`, TAG);
     });
     logger.debug("... HTTP server startup requested.", TAG);
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, the port by which data-broker listens is fixed at `80`.


* **What is the new behavior (if this is a feature change)?**
Port can be configured by setting `SERVICE_PORT` environment variable. Default port is still `80`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#1203

* **Other information**:
