### PR TITLE
Change Redis images version to a fix one

### DIFF
--- a/local/compose.yml
+++ b/local/compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
   data-broker-redis:
-    image: "redis"
+    image: "redis:5.0.5-alpine3.10"
 
   zookeeper:
     image: "zookeeper:3.4"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: always
 
   data-broker-redis:
-    image: redis
+    image: "redis:5.0.5-alpine3.10"
     restart: always
     networks:
       default:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Data Broker Redis image version is alpine, which is not a fixed one, it is the latest with alpine. The latest version breaks the Travis CI build in data-broker PRs, making it impossible to merge them.


* **What is the new behavior (if this is a feature change)?**
Fix Data Broker Redis image version in 5.0.5-alpine3.10


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I've tested the application and no problems were found.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
https://github.com/dojot/dojot/issues/1233

* **Other information**:
