### PR TITLE
[v0.5.0] - upgrade "dojot-module" library from 0.0.1-beta.5 to 0.0.1-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@dojot/adminkafka": "0.0.1-alpha.9",
-    "@dojot/dojot-module": "0.0.1-beta.5",
+    "@dojot/dojot-module": "0.0.1-beta.9",
     "@dojot/dojot-module-logger": "0.0.1-alpha.5",
     "@dojot/healthcheck": "^0.0.1-alpha",
     "@types/body-parser": "^1.16.5",


### PR DESCRIPTION
Ticket(s): dojot/dojot#1730